### PR TITLE
Token lists: complement a RegExp pattern for valid token names

### DIFF
--- a/src/components/ListLogo/index.tsx
+++ b/src/components/ListLogo/index.tsx
@@ -4,18 +4,18 @@ import useHttpLocations from '../../hooks/useHttpLocations'
 
 import Logo from '../Logo'
 
-const StyledListLogo = styled(Logo)<{ size: string }>`
+const StyledListLogo = styled(Logo) <{ size: string }>`
   width: ${({ size }) => size};
   height: ${({ size }) => size};
 `
 
 export default function ListLogo({
-  logoURI,
+  logoURI = '',
   style,
   size = '24px',
   alt,
 }: {
-  logoURI: string
+  logoURI?: string
   size?: string
   style?: React.CSSProperties
   alt?: string

--- a/src/components/SearchModal/ManageLists.tsx
+++ b/src/components/SearchModal/ManageLists.tsx
@@ -96,11 +96,7 @@ const CustomListRow = memo(function CustomListRow({ list }: { list: TokenList; k
 
   return (
     <RowWrapper active={false} bgColor={listColor} id={list.name}>
-      {list.logoURI ? (
-        <ListLogo size="40px" style={{ marginRight: '1rem' }} logoURI={list.logoURI} alt={`${list.name} list logo`} />
-      ) : (
-        <div style={{ width: '24px', height: '24px', marginRight: '1rem' }} />
-      )}
+      <ListLogo size="40px" style={{ marginRight: '1rem' }} logoURI={list.logoURI} alt={`${list.name} list logo`} />
       <Column style={{ flex: '1' }}>
         <Row>
           <StyledTitleText active={false}>{list.name}</StyledTitleText>

--- a/src/utils/list.ts
+++ b/src/utils/list.ts
@@ -20,8 +20,9 @@ export function listVersionLabel(version: Version): string {
 export function filterTokenLists(chainId: number, lists: { [listId: string]: any }) {
   return Object.values(lists).filter((list: any) => {
     try {
-      const namePattern = /^[a-zA-Z0-9+\-%/$]+$/
-      const filteredTokens = list.tokens
+      // eslint-disable-next-line
+      const namePattern = /^[a-zA-Z0-9+\\\-%\/$.() ]+$/
+      let filteredTokens = list.tokens
         // filter not valid token before actuall external validation
         // to leave the option of showing the entire token list
         // (without it token list won't be displayed with an error in at least one token)


### PR DESCRIPTION
Issue: [#48](https://github.com/noxonsu/definance/issues/48)

- fix RegExp for token lists' validation
- display a question mark if we don't have token list URL

--- 

![1](https://user-images.githubusercontent.com/61930014/188311684-66686c93-faa5-4c11-a9d0-e4372ee5ca05.png)

![2](https://user-images.githubusercontent.com/61930014/188311688-65c0655d-8dc0-43b4-87af-40f117301abd.png)
